### PR TITLE
Remove logging of user provided data

### DIFF
--- a/backend/src/main/java/com/knightsofdarkness/web/game/GameController.java
+++ b/backend/src/main/java/com/knightsofdarkness/web/game/GameController.java
@@ -24,7 +24,6 @@ public class GameController {
     @PostMapping("/config")
     ResponseEntity<GameConfig> getConfig(@AuthenticationPrincipal UserData currentUser)
     {
-        log.info("User {} requested game config", currentUser);
         if (currentUser == null)
         {
             log.error("User not read from authentication context");

--- a/backend/src/main/java/com/knightsofdarkness/web/kingdom/KingdomController.java
+++ b/backend/src/main/java/com/knightsofdarkness/web/kingdom/KingdomController.java
@@ -62,8 +62,6 @@ public class KingdomController
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
         }
 
-        log.info("User {} requested kingdom", currentUser.email);
-
         return kingdomService.getKingdomByName(currentUser.getKingdomName())
                 .map(ResponseEntity::ok)
                 .orElse(ResponseEntity.notFound().build());
@@ -78,7 +76,6 @@ public class KingdomController
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
         }
 
-        log.info("User {} requested kingdom stats", currentUser.email);
         return ResponseEntity.ok(kingdomService.getTopKingdomsStats());
     }
 


### PR DESCRIPTION
Fixes #45

Remove logging of user-provided data such as `user.email` in `GameController` and `KingdomController`.

* **GameController.java**
  - Remove logging of `currentUser` in `getConfig` method.

* **KingdomController.java**
  - Remove logging of `currentUser.email` in `getKingdom` method.
  - Remove logging of `currentUser.email` in `getKingdomsStats` method.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/lmerynda/KnightsOfDarkness/pull/46?shareId=e4d33988-5fa9-4cb8-a88d-8a45dae10d92).